### PR TITLE
Architect sent 2nd to last score twice

### DIFF
--- a/architect.py
+++ b/architect.py
@@ -31,6 +31,7 @@ for i in range(19):
     best_score = max(best_score, score)
     matchmaker.send_score_and_get_candidate(score)
 
+score = np.dot(matchmaker.weight_guess, person.weights)
 matchmaker.send_score(score)
 best_score = max(best_score, score)
 


### PR DESCRIPTION
Fix architect not recalculating the score for the matchmaker's last guess before sending the score back.

This also fixes an incorrect score if the matchmaker's best guess was his 20th candidate.